### PR TITLE
EN-132:  Added header for rejecting unknown properties

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,6 +2,7 @@
   "curly": true,
   "eqnull": true,
   "eqeqeq": true,
+  "esversion": 6,
   "undef": true,
   "unused": true,
   "smarttabs": false,

--- a/lib/content.js
+++ b/lib/content.js
@@ -1,7 +1,8 @@
 var logger = require('./logger');
 var lodash = require('lodash');
-var specSchema= require('./spec-schema');
+var specSchema = require('./spec-schema');
 var contentTypeChecker = require('./content-type');
+var strictSchemas = require('./strict-schemas');
 
 var isJson = contentTypeChecker.isJson;
 
@@ -95,14 +96,19 @@ exports.matchesBody = function(httpReq, specReq) {
 };
 
 exports.matchesSchema = function(httpReq, specReq) {
-
-    if (!specReq){
-        return true;
+    if (!specReq || !specReq.schema) {
+        return {
+            valid: false
+        };
     }
+    let rejectUnknownProps = strictSchemas.rejectUnknownProps(httpReq);
+
+    let schema = rejectUnknownProps ? strictSchemas.getStrictSchema(specReq.schema)
+        : specReq.schema;
 
     var contentType = getMediaTypeFromHttpReq(httpReq);
     var reqBody = getBodyContent(httpReq, isJson(contentType));
-    var result =  specSchema.matchWithSchema(reqBody, specReq.schema);
+    var result =  specSchema.matchWithSchema(reqBody, schema);
     logger.log('[MATCHING]'.yellow,'by request body schema', logger.stringfy(result.valid));
     return result;
 };

--- a/lib/handler-filter.js
+++ b/lib/handler-filter.js
@@ -14,18 +14,6 @@ var filterRequestBody = function(req) {
     };
 };
 
-var checkSchema = function(req) {
-    return function(handler) {
-
-        var result =  content.matchesSchema(req, handler.request);
-
-        return {
-            handler: handler,
-            result: result
-        };
-    };
-};
-
 function isJsonContent(req) {
     if(req && req.headers) {
         return /json/i.test(req.headers['content-type']);
@@ -61,7 +49,14 @@ exports.filterHandlers = function(req, handlers, ignoreHeaders) {
 
         if(isJsonContent(req)) {
 
-            var validatedHandlers = filteredHandlers.map(checkSchema(req));
+            let validatedHandlers = filteredHandlers.map((handler) => {
+                let result = content.matchesSchema(req, handler.request);
+
+                return {
+                    handler,
+                    result
+                };
+            });
 
             var matchSchemaHandlers = validatedHandlers.filter(function(handler) {
                 return handler.result.valid;
@@ -72,7 +67,7 @@ exports.filterHandlers = function(req, handlers, ignoreHeaders) {
             }
 
             var errorHandlers = validatedHandlers.filter(function(handler) {
-                return handler.result.niceErrors.length;
+                return handler.result.niceErrors;
             });
 
             if(errorHandlers.length > 0) {

--- a/lib/middleware/route-handlers.js
+++ b/lib/middleware/route-handlers.js
@@ -20,6 +20,7 @@ module.exports = function(options, cb) {
 
                 // req.path allows us to delegate query string handling to the route handler functions
                 var match = regex.exec(req.path);
+
                 logger.log('[MATCHING]'.yellow, 'by url pattern:', urlPattern.yellow, logger.stringfy(match));
                 if (match) {
                     var handlers = routeMap[urlPattern].methods[req.method.toUpperCase()];

--- a/lib/spec-schema.js
+++ b/lib/spec-schema.js
@@ -18,12 +18,8 @@ exports.hasSchema = function(spec) {
 };
 
 exports.matchWithSchema = function(json, schema) {
-    if (!schema) {
-        return {
-            valid: false
-        };
-    }
-    var result = tv4.validateMultiple(json, schema);
+
+    let result = tv4.validateMultiple(json, schema);
 
     if (!result.valid) {
 

--- a/lib/strict-schemas.js
+++ b/lib/strict-schemas.js
@@ -1,0 +1,25 @@
+
+//cache updated maps
+const schemaMap = new Map();
+
+exports.rejectUnknownProps = (req) => req.headers['reject-unknown-props'] === 'true';
+
+exports.getStrictSchema = (schema) => {
+    if (!schemaMap.has(schema)) {
+        schemaMap.set(schema, addAddtionalPropsFalse(schema));
+    }
+
+    return schemaMap.get(schema);
+};
+
+function addAddtionalPropsFalse(schema) {
+    let newSchema = Object.assign({}, schema, {additionalProperties: false});
+    Object.keys(schema.properties).forEach(key =>{
+        let child = schema.properties[key];
+        if (child.type === 'object') {
+            schema.properties[key] = addAddtionalPropsFalse(child);
+        }
+    });
+
+    return newSchema;
+}

--- a/test/api/additional-properties-test.js
+++ b/test/api/additional-properties-test.js
@@ -1,0 +1,36 @@
+var helper = require('../lib');
+var request = helper.getRequest();
+
+describe('Reject addtional properties', function(){
+    before(function (done) {
+        helper.drakov.run({sourceFiles: 'test/example/md/json-schema.md'}, done);
+    });
+
+    after(function (done) {
+        helper.drakov.stop(done);
+    });
+
+    describe('POST with additional properties', function(){
+        describe('when the `reject-unknown-props` header is false', function(){
+            it('should respond with success', function(done){
+                request.post('/notes')
+                .set('Content-type', 'application/json')
+                .send({id: 1, moo: 'moo'})
+                .expect(201)
+                .end(helper.endCb(done));
+            });
+        });
+
+        describe('when the `reject-unknown-props` header is true', function(){
+            it('should reject with error message', function(done){
+                request.post('/notes')
+                    .set('Content-type', 'application/json')
+                    .set('reject-unknown-props', true)
+                    .send({id: 1, moo: 'moo'})
+                    .expect(400, '["/moo Additional properties not allowed"]')
+                    .end(helper.endCb(done));
+            });
+        });
+    });
+
+});

--- a/test/api/additional-properties-test.js
+++ b/test/api/additional-properties-test.js
@@ -1,7 +1,7 @@
 var helper = require('../lib');
 var request = helper.getRequest();
 
-describe('Reject addtional properties', function(){
+describe('Reject additional properties', function(){
     before(function (done) {
         helper.drakov.run({sourceFiles: 'test/example/md/json-schema.md'}, done);
     });

--- a/test/unit/content-test.js
+++ b/test/unit/content-test.js
@@ -79,7 +79,7 @@
                 body: '{"text": "Hyperspeed jet"}',
             };
 
-            context('when spec does not define', function ()  {
+            context('when spec is not defined', function ()  {
 
                 it('should return true', function () {
                     var specReq = null;
@@ -224,22 +224,13 @@
                 body: '{"first": "text", "second": "text2"}'
             };
 
+
             context('when spec is not defined', function () {
 
                 var specReq = null;
 
-                it('should return true', function () {
-                    assert.equal(content.matchesSchema(httpReq, specReq), true);
-                });
-
-                it('should log to console that schema is matched', function () {
-                    var hook = stdoutHook.setup(function (string) {
-                        assert.equal(loadash.includes(string, 'NOT_MATCHED'), false);
-                    });
-
-                    content.matchesSchema(httpReq, specReq);
-
-                    hook();
+                it('should return `{valid:false}`', function () {
+                    assert.deepEqual(content.matchesSchema(httpReq, specReq), {valid: false});
                 });
             });
 

--- a/test/unit/spec-schema-test.js
+++ b/test/unit/spec-schema-test.js
@@ -13,7 +13,13 @@ var schema =  {
     required: ['id'],
     properties: {
         id: {type: 'number'},
-        title: {type: 'string' }
+        title: {type: 'string'},
+        third: {
+            type: 'object',
+            properties: {
+                inner: {type: 'string'}
+            },
+        },
     }
 };
 
@@ -39,13 +45,13 @@ describe('Spec Schema', function() {
             }]
         };
 
-        var validateMultiple;
+        var validateMultipleMock;
         var logSpy;
 
         beforeEach(function() {
-            validateMultiple = sinon.stub(tv4, 'validateMultiple');
-            validateMultiple.withArgs(valid, schema).returns({valid: true});
-            validateMultiple.returns(invalid);
+            validateMultipleMock = sinon.stub(tv4, 'validateMultiple');
+            validateMultipleMock.withArgs(valid, schema).returns({valid: true});
+            validateMultipleMock.returns(invalid);
 
             logSpy = sinon.spy(logger, 'log');
         });

--- a/test/unit/strict-schemas-test.js
+++ b/test/unit/strict-schemas-test.js
@@ -1,0 +1,38 @@
+const assert = require ('assert');
+const strictSchemas = require('../../lib/strict-schemas');
+const schema =  {
+    type: 'object',
+    required: ['id'],
+    properties: {
+        id: {type: 'number'},
+        title: {type: 'string'},
+        third: {
+            type: 'object',
+            properties: {
+                inner: {type: 'string'}
+            },
+        },
+    }
+};
+
+describe('strictSchemas', () => {
+    describe('rejectUnknownProps', () => {
+        describe('when the request has reject-unknown-props == "true"', () => {
+            it('returns true', () => {
+                assert.strictEqual(strictSchemas.rejectUnknownProps({headers: {'reject-unknown-props': 'true'}}), true);
+            });
+        });
+
+    });
+
+    describe('getStrictSchema', () => {
+        it('should add the `additionalProperties: false` to each object', () => {
+
+            const strictSchema = strictSchemas.getStrictSchema(schema);
+
+            assert.strictEqual(strictSchema.additionalProperties, false, 'parent schema missing property');
+            assert.strictEqual(strictSchema.properties.third.additionalProperties, false, 'child missing proptery');
+
+        });
+    });
+});


### PR DESCRIPTION
- when adding header  the mock server will reject any request with a property not listed in the spec
- error message will be of form "/<propName> Additional properties not allowed"