### PR TITLE
Change matching algorithm so that to not match example bodies

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -81,8 +81,8 @@ exports.matchesBody = function(httpReq, specReq) {
         return true;
     }
 
-    //if a schema is present, don't match with an empty body
-    if (specReq.schema && !httpReq.body) {
+    //if a schema is present, don't match body
+    if (specReq.schema) {
         return false;
     }
 

--- a/lib/handler-filter.js
+++ b/lib/handler-filter.js
@@ -40,7 +40,7 @@ exports.filterHandlers = function(req, handlers, ignoreHeaders) {
         });
 
         if (matchRequestBodyHandlers.length > 0) {
-            return addMatchesByHeader(matchRequestBodyHandlers[0], 'matches-request-body');
+            return addHeaderForSucessfulMatchingStrategy(matchRequestBodyHandlers[0], 'matches-request-body');
         }
 
         if(isJsonContent(req)) {
@@ -59,7 +59,7 @@ exports.filterHandlers = function(req, handlers, ignoreHeaders) {
             });
 
             if (matchSchemaHandlers.length > 0) {
-                return addMatchesByHeader(matchSchemaHandlers[0].handler, 'matches-request-schema');
+                return addHeaderForSucessfulMatchingStrategy(matchSchemaHandlers[0].handler, 'matches-request-schema');
             }
 
             var errorHandlers = validatedHandlers.filter(function(handler) {
@@ -75,7 +75,7 @@ exports.filterHandlers = function(req, handlers, ignoreHeaders) {
     return null;
 };
 
-function addMatchesByHeader(originalHandler, matchType) {
+function addHeaderForSucessfulMatchingStrategy(originalHandler, matchType) {
     const header = {name: 'X-Matched-By', value: matchType};
     let handler = Object.assign({}, originalHandler);
     if (handler.response.headers) {

--- a/lib/handler-filter.js
+++ b/lib/handler-filter.js
@@ -40,7 +40,7 @@ exports.filterHandlers = function(req, handlers, ignoreHeaders) {
         });
 
         if (matchRequestBodyHandlers.length > 0) {
-            return matchRequestBodyHandlers[0];
+            return addMatchesByHeader(matchRequestBodyHandlers[0], 'matches-request-body');
         }
 
         if(isJsonContent(req)) {
@@ -59,7 +59,7 @@ exports.filterHandlers = function(req, handlers, ignoreHeaders) {
             });
 
             if (matchSchemaHandlers.length > 0) {
-                return matchSchemaHandlers[0].handler;
+                return addMatchesByHeader(matchSchemaHandlers[0].handler, 'matches-request-schema');
             }
 
             var errorHandlers = validatedHandlers.filter(function(handler) {
@@ -74,3 +74,14 @@ exports.filterHandlers = function(req, handlers, ignoreHeaders) {
 
     return null;
 };
+
+function addMatchesByHeader(originalHandler, matchType) {
+    const header = {name: 'X-Matched-By', value: matchType};
+    let handler = Object.assign({}, originalHandler);
+    if (handler.response.headers) {
+        handler.response.headers.push(header);
+    } else {
+        handler.response.headers = [header];
+    }
+    return handler;
+}

--- a/lib/handler-filter.js
+++ b/lib/handler-filter.js
@@ -8,12 +8,6 @@ var filterRequestHeader = function(req, ignoreHeaders) {
     };
 };
 
-var filterRequestBody = function(req) {
-    return function(handler) {
-        return content.matchesBody(req, handler.request);
-    };
-};
-
 function isJsonContent(req) {
     if(req && req.headers) {
         return /json/i.test(req.headers['content-type']);
@@ -41,7 +35,9 @@ exports.filterHandlers = function(req, handlers, ignoreHeaders) {
             return null;
         }
 
-        var matchRequestBodyHandlers = filteredHandlers.filter(filterRequestBody(req));
+        var matchRequestBodyHandlers = filteredHandlers.filter((handler) => {
+            return content.matchesBody(req, handler.request);
+        });
 
         if (matchRequestBodyHandlers.length > 0) {
             return matchRequestBodyHandlers[0];

--- a/test/api/matched-by-headers-test.js
+++ b/test/api/matched-by-headers-test.js
@@ -1,0 +1,46 @@
+var helper = require('../lib');
+var request = helper.getRequest();
+
+describe('matches-by-headers', () => {
+
+    before((done) => {
+        helper.drakov.run({sourceFiles: 'test/example/md/matched-by-headers-api.apib',
+          ignoreHeader: ['Cookie']}, done);
+    });
+
+    after((done) => {
+        helper.drakov.stop(done);
+    });
+
+    describe('/demo', () => {
+
+        describe('when the request matches a schema', () => {
+            it('should have the `x-matched-by: matches-request-schema` header', (done) => {
+                request.post('/demo')
+                .send({
+                    'question': 'Why?',
+                    'choices': ['Why not?', 'BECAUSE!']
+                })
+                .expect(200)
+                .expect('X-Matched-By', 'matches-request-schema')
+                .end(helper.endCb(done));
+            });
+        });
+
+
+        describe('when the request matches a body', () => {
+            it('should have the `x-matched-by: matches-request-body` header', (done) => {
+                request.post('/demo')
+                .send({
+                    'question': 'Why?',
+                    'choices': ['who knows?', 'BECAUSE!']
+                })
+                .expect(200)
+                .expect('X-Matched-By', 'matches-request-body')
+                .end(helper.endCb(done));
+            });
+        });
+    });
+
+
+});

--- a/test/api/matched-by-headers-test.js
+++ b/test/api/matched-by-headers-test.js
@@ -12,29 +12,32 @@ describe('matches-by-headers', () => {
         helper.drakov.stop(done);
     });
 
-    describe('/demo', () => {
+    describe('given the request body matches a schema but does not equal the body in the spec', () => {
+        const validBodyThatIsNotExactMatchWithSpecBody = {
+            'question': 'Why?',
+            'choices': ['Why not?', 'BECAUSE!']
+        };
 
-        describe('when the request matches a schema', () => {
-            it('should have the `x-matched-by: matches-request-schema` header', (done) => {
+        describe('when validating the request', () => {
+            it('the request is matched by schema and the response should have the `x-matched-by: matches-request-schema` header', (done) => {
                 request.post('/demo')
-                .send({
-                    'question': 'Why?',
-                    'choices': ['Why not?', 'BECAUSE!']
-                })
+                .send(validBodyThatIsNotExactMatchWithSpecBody)
                 .expect(200)
                 .expect('X-Matched-By', 'matches-request-schema')
                 .end(helper.endCb(done));
             });
         });
+    });
 
-
-        describe('when the request matches a body', () => {
-            it('should have the `x-matched-by: matches-request-body` header', (done) => {
+    describe('given the request body is an exact match to body in the spec', () => {
+        const bodyThatMatchesSpecBodyExactly = {
+            'question': 'Why?',
+            'choices': ['who knows?', 'BECAUSE!']
+        };
+        describe('when validating the request', () => {
+            it('the request is matched by body and the response should have the `x-matched-by: matches-request-body` header', (done) => {
                 request.post('/demo')
-                .send({
-                    'question': 'Why?',
-                    'choices': ['who knows?', 'BECAUSE!']
-                })
+                .send(bodyThatMatchesSpecBodyExactly)
                 .expect(200)
                 .expect('X-Matched-By', 'matches-request-body')
                 .end(helper.endCb(done));

--- a/test/example/md/matched-by-headers-api.apib
+++ b/test/example/md/matched-by-headers-api.apib
@@ -1,0 +1,52 @@
+# Note [/demo]
+
+## Add a Note [POST]
+
++ Request (application/json)
+
+    + Body
+    ```json
+        {
+            "question": "Why?",
+            "choices": ["Why not?", "BECAUSE!"]
+        }
+    ```
+
+
+    + Schema
+    ```json
+            {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "required": ["question", "choices"],
+              "type": "object",
+              "properties": {
+                "question": {
+                  "type": "string"
+                },
+                "choices": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 2
+                }
+              }
+             
+            }
+    ```
+
++ Response 200 (application/json)
+
+
++ Request (application/json)
+
+    + Body
+    ```json
+        {
+            "question": "Why?",
+            "choices": ["who knows?", "BECAUSE!"]
+        }
+    ```
+
++ Response 200 (application/json)
+

--- a/test/example/md/multiple-examples-api.md
+++ b/test/example/md/multiple-examples-api.md
@@ -80,16 +80,6 @@ Get examples with a specific status code (eg. 400)
                 "title": "hello"
             }
 
-    + Schema
-
-            {
-                "type": "object",
-                "required": ["id"],
-                "properties": {
-                    "id": {"type": "number"},
-                    "title": {"type": "string" }
-                }
-            }
 
 + Response 400 (application/json)
 


### PR DESCRIPTION
This is to fix the issue with validating contracts with themselves. Previously, a request body example would match itself. Now drakov will only match an exact body if a schema is not present for that request response pair. 