### PR TITLE
Feature/use relative paths

### DIFF
--- a/src/lib/middleware/route-map.js
+++ b/src/lib/middleware/route-map.js
@@ -3,7 +3,7 @@ const glob = require('glob');
 const async = require('async');
 const parseBlueprint = require('../parse/blueprint');
 const endpointSorter = require('./endpoint-sorter');
-import type {Contract} from '../parse/contracts';
+import type { Contract } from '../parse/contracts';
 
 type Options = {
     sourceFiles: ?Array<string>,
@@ -12,7 +12,7 @@ type Options = {
 }
 type EndpointCb = (err: Error, endpoints?: Array<any>) => void;
 
-module.exports = function(options: Options, cb: EndpointCb) {
+module.exports = function (options: Options, cb: EndpointCb) {
     const sourceFiles = options.sourceFiles;
     const autoOptions = options.autoOptions;
     const contracts = options.contracts;
@@ -20,8 +20,10 @@ module.exports = function(options: Options, cb: EndpointCb) {
 
     if (contracts) {
         contracts.forEach(contract => {
-            const files = glob.sync(`${contract.fixtureFolder}/*.?(apib|md)`);
-            setupRouteMap(files, contract);
+            contract.fixtureFolders.forEach(fixtureFolder => {
+                const files = glob.sync(`${fixtureFolder}/*.?(apib|md)`);
+                setupRouteMap(files, contract);
+            });
         });
     } else if (sourceFiles) {
         const files = glob.sync(sourceFiles);
@@ -34,11 +36,11 @@ module.exports = function(options: Options, cb: EndpointCb) {
 
         const asyncFunctions = [];
 
-        files.forEach(function(filePath) {
+        files.forEach(function (filePath) {
             asyncFunctions.push(parseBlueprint(filePath, autoOptions, routeMap, contract));
         });
 
-        async.series(asyncFunctions, function(err) {
+        async.series(asyncFunctions, function (err) {
             cb(err, endpointSorter.sortByMatchingPriority(routeMap));
         });
     }

--- a/src/test/api/contract-fixture-validation-test.js
+++ b/src/test/api/contract-fixture-validation-test.js
@@ -1,7 +1,7 @@
 const helper = require('../lib');
 const request = helper.getRequest();
 
-describe.only('Contract Fixture Validation', () => {
+describe('Contract Fixture Validation', () => {
     describe('GIVEN drakov is run in non-validation mode', () => {
         before((done) => {
             helper.drakov.run({ sourceFiles: 'src/test/example/fixtures/contract-fixture-validation.apib' }, done);

--- a/src/test/example/contract/contract-fixture-mapping.json
+++ b/src/test/example/contract/contract-fixture-mapping.json
@@ -1,3 +1,3 @@
 {
-    "src/test/example/contract/contract-fixture-validation.apib": "src/test/example/fixtures"
+    "contract-fixture-validation.apib": ["../fixtures"]
 }

--- a/src/test/unit/contracts-test.js
+++ b/src/test/unit/contracts-test.js
@@ -43,21 +43,27 @@ describe('readContractFixtureMap', () => {
             });
         });
         describe('AND the file is parsable', () => {
-            it('WHEN calling readContractFixtureMap THEN it returns a map of contracts to fixtures', () => {
-                const mapping: Mappings = {
-                    contract1: 'fixture 1',
-                    contract2: 'fixture 2'
+            it('WHEN calling readContractFixtureMap' +
+                    'THEN it returns a map of contracts to fixtures with the relative path added to non-http paths', () => {
+                 const mappingFileContents: Mappings = {
+                    'https://contract1': ['fixture1'],
+                    'contract2': ['fixture2']
                 };
 
-                readFileStub.withArgs('1').returns(JSON.stringify(mapping));
-                assert.deepEqual(contracts.readContractFixtureMap('1'), mapping);
+                const expectedMapping: Mappings = {
+                    'https://contract1': ['relative/path/fixture1'],
+                    'relative/path/contract2': ['relative/path/fixture2']
+                };
+                readFileStub.withArgs('relative/path/1').returns(JSON.stringify(mappingFileContents));
+                assert.deepEqual(contracts.readContractFixtureMap('relative/path/1'), expectedMapping);
             });
+
         });
     });
 });
 
 describe('parseContracts', () => {
-    const mapping: Mappings = { 'contract': 'fixture' }
+    const mapping: Mappings = { 'contract': ['fixture'] }
 
     let validateSchemaStub;
     let urlStub;
@@ -84,7 +90,7 @@ describe('parseContracts', () => {
     describe('GIVEN the contract file starts with "http(s)://"', () => {
         const myContractUrl = 'https://myContractUrl';
 
-        const mappingWithUrl: Mappings = { [myContractUrl]: 'fixture' }
+        const mappingWithUrl: Mappings = { [myContractUrl]: ['fixture'] }
         const contractContents = 'myOnlineContract';
 
         it('WHEN calling readContractFixtureMap THEN it will try to fetch the file online', async () => {
@@ -148,7 +154,7 @@ describe('parseContracts', () => {
                 examples: [example]
             };
             const expected: Contract = {
-                fixtureFolder: 'fixture',
+                fixtureFolders: ['fixture'],
                 resources: {
                     'final url': {
                         'POST': {


### PR DESCRIPTION
Paths in the contract-fixture mapping file are now considered relative to that file

Fix issue with fixture mapping type inconsistency: some code referred to it as a string; it is now always an array of strings