### PR TITLE
Add more specific responses when endpoint matching fails

### DIFF
--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -116,7 +116,7 @@ exports.matchesSchema = function(httpReq, specReq) {
     var result =  specSchema.matchWithSchema(reqBody, schema);
     logger.debug('Matching by request body schema', renderMatchType(result.valid));
     if (!result.valid) {
-        logger.debug(result.niceErrors);
+        logger.debug(result.formattedErrors);
     }
     return result;
 };

--- a/src/lib/handler-filter.js
+++ b/src/lib/handler-filter.js
@@ -31,12 +31,12 @@ exports.filterHandlers = function (req, handlers, ignoreHeaders) {
 
         filteredHandlers = handlers.filter(filterRequestHeader(req, ignoreHeaders));
         if (filteredHandlers.length === 0) {
-            return route.createErrorHandler(handlers[0],["No handler matches after filtering required headers (including content-type)"])
+            return route.createErrorHandler(handlers[0],["Found URL but request doesn't contain required headers to match against any known fixture"])
         }
 
         filteredHandlers = urlQueryParams.filterForRequired(req, filteredHandlers);
         if (filteredHandlers.length === 0) {
-            return route.createErrorHandler(handlers[0],["No handler matches after filtering required query parameters"])
+            return route.createErrorHandler(handlers[0],["Found URL but request doesn't contain required query parameters to match against any known fixture"])
 
         }
 

--- a/src/lib/handler-filter.js
+++ b/src/lib/handler-filter.js
@@ -27,17 +27,23 @@ function addRequestHeaderCount(handler) {
 
 exports.filterHandlers = function (req, handlers, ignoreHeaders) {
     if (handlers) {
-        var filteredHandlers;
+        let filteredHandlers;
 
-        handlers.sort(content.contentTypeComparator);
+        filteredHandlers = handlers.filter(filterRequestHeader(req, ignoreHeaders));
+        if (filteredHandlers.length === 0) {
+            return route.createErrorHandler(handlers[0],["No handler matches after filtering required headers (including content-type)"])
+        }
 
-        filteredHandlers = urlQueryParams.filterForRequired(req, handlers);
+        filteredHandlers = urlQueryParams.filterForRequired(req, filteredHandlers);
+        if (filteredHandlers.length === 0) {
+            return route.createErrorHandler(handlers[0],["No handler matches after filtering required query parameters"])
+
+        }
+
         let queryParams = req.query;
         urlQueryParams.countMatchingQueryParams(handlers, queryParams);
 
-        filteredHandlers = filteredHandlers.filter(filterRequestHeader(req, ignoreHeaders));
-
-        // prioritize handlers that have more headers where all headers match. 
+        // prioritize handlers that have more headers where all headers match.
         // this allows us to safely ignore extra headers being sent
         // then prioritize based on query params
         filteredHandlers.forEach(addRequestHeaderCount);
@@ -80,11 +86,11 @@ exports.filterHandlers = function (req, handlers, ignoreHeaders) {
             }
 
             var errorHandlers = validatedHandlers.filter(function (handler) {
-                return handler.result.niceErrors;
+                return handler.result.formattedErrors;
             });
 
             if (errorHandlers.length > 0) {
-                return route.createErrorHandler(errorHandlers[0]);
+                return route.createErrorHandler(errorHandlers[0].handler, errorHandlers[0].result.formattedErrors);
             }
         }
     }

--- a/src/lib/parse/contracts.js
+++ b/src/lib/parse/contracts.js
@@ -259,7 +259,7 @@ const validateBody = (fixtureBody?: BodyDescriptor, contractSchema: JsonSchema):
             const validated = schemaValidator.matchWithSchema(parsedBody, contractSchema);
             result = {
                 valid: validated.valid,
-                message:  validated.niceErrors && `${validated.niceErrors.join('; ')}`,
+                message:  validated.formattedErrors && `${validated.formattedErrors.join('; ')}`,
             }
         }
     } catch (e) {

--- a/src/lib/route.js
+++ b/src/lib/route.js
@@ -50,7 +50,7 @@ exports.getRouteHandlers = function (parsedUrl, action, queryParams) {
     });
 };
 
-exports.createErrorHandler = function(validatedHandler) {
+exports.createErrorHandler = function(handler, formattedErrors) {
 
     var execute = function (req, res) {
         const httpRequest = {
@@ -64,13 +64,11 @@ exports.createErrorHandler = function(validatedHandler) {
         const message = [this.action.method.green, this.parsedUrl.uriTemplate.yellow,
             (this.request && this.request.description ? this.request.description : this.action.name).blue].join(' ');
         logger.logHttpRequest(message, httpRequest);
-        this.response.headers.forEach(function (header) {
-            res.set(header.name, header.value);
-        });
 
+        res.set("Content-type", "application/json");
         res.status(400);
-        res.send(buildResponseBody(validatedHandler.result.niceErrors));
+        res.send(buildResponseBody(formattedErrors));
     };
 
-    return Object.assign({}, validatedHandler.handler, {execute: execute});
+    return Object.assign({}, handler, {execute: execute});
 };

--- a/src/lib/spec-schema.js
+++ b/src/lib/spec-schema.js
@@ -20,14 +20,14 @@ exports.matchWithSchema = function(json, schema) {
 
     let result = tv4.validateMultiple(json, schema);
 
-    var niceErrors = [];
+    let formattedErrors = [];
     if (!result.valid) {
 
         result.errors.forEach(function(error) {
-            niceErrors.push(error.dataPath + ' ' + error.message);
+            formattedErrors.push(error.dataPath + ' ' + error.message);
         });
 
-        result.niceErrors = niceErrors;
+        result.formattedErrors = formattedErrors;
     }
 
     return result;

--- a/src/test/api/multipart-test.js
+++ b/src/test/api/multipart-test.js
@@ -27,7 +27,7 @@ describe('Multipart Requests', function() {
             .send()
             .expect(400)
             .expect('Content-type', 'application/json; charset=utf-8')
-            .expect([ 'No handler matches after filtering required headers (including content-type)' ])
+            .expect([ 'Found URL but request doesn\'t contain required headers to match against any known fixture' ])
             .end(helper.endCb(done));
         });
     });

--- a/src/test/api/multipart-test.js
+++ b/src/test/api/multipart-test.js
@@ -25,8 +25,9 @@ describe('Multipart Requests', function() {
             request.post('/api/multipart')
             .set('Content-type', 'application/json')
             .send()
-            .expect(404)
-            .expect('Content-type', 'text/html; charset=utf-8')
+            .expect(400)
+            .expect('Content-type', 'application/json; charset=utf-8')
+            .expect([ 'No handler matches after filtering required headers (including content-type)' ])
             .end(helper.endCb(done));
         });
     });

--- a/src/test/unit/content-test.js
+++ b/src/test/unit/content-test.js
@@ -286,7 +286,7 @@
                 it('should contain valid === false and a nice error message', function () {
                     var result = content.matchesSchema(httpReq, specReq);
                     assert.equal(result.valid, false);
-                    assert.equal(result.niceErrors, '/first Invalid type: string (expected number)');
+                    assert.equal(result.formattedErrors, '/first Invalid type: string (expected number)');
                 });
 
                 it('should log to console that schema is not matched', function () {

--- a/src/test/unit/contracts-test.js
+++ b/src/test/unit/contracts-test.js
@@ -480,7 +480,7 @@ describe('removeInvalidFixtures', () => {
                 .returns({valid: true});
 
             matchWithSchemaStub.withArgs(JSON.parse(badFixtureBody), contractActions['POST'].responses[0].schema)
-                .returns({valid: false, niceErrors: ['some error passed from the validator']});
+                .returns({valid: false, formattedErrors: ['some error passed from the validator']});
                 assert.deepEqual(contracts.removeInvalidFixtures(fixture, contractActions), expectedResource);
             assert.equal(errorSpy.getCall(0).args[0], 'POST /sample-url example[0] response matches no contract response:\n' +
                 '\tFor contract response[0]: some error passed from the validator\n' +

--- a/src/test/unit/spec-schema-test.js
+++ b/src/test/unit/spec-schema-test.js
@@ -61,7 +61,7 @@ describe('Spec Schema', function() {
         });
 
         describe('when the body does not match schema', function() {
-            var expected = Object.assign({niceErrors: ['Do you feel lucky, punk?']}, invalid);
+            var expected = Object.assign({formattedErrors: ['Do you feel lucky, punk?']}, invalid);
             it('Should return false when json is not validated against schema and log ERROR', function () {
                 assert.deepEqual(specSchema.matchWithSchema({idea: 1}, schema), expected);
 


### PR DESCRIPTION
When a request is not matched due to parameter or header validation, the response is now 400 (rather than 404) and a more useful error message is returned.