### PR TITLE
Ignore unknown types when validating headers and parameters

### DIFF
--- a/src/lib/parse/headers.js
+++ b/src/lib/parse/headers.js
@@ -1,7 +1,8 @@
-"use strict"
+"use strict";
 //@flow
 
 const types = require('./types-checker');
+const logger = require('../logging/logger');
 
 export type HeaderDef = {
     name: string,
@@ -42,10 +43,16 @@ const parseHeaderValue = (rawHeader: HeaderDef): HeaderDef => {
             default:
                 throw new Error(`For header "${rawHeader.name}", unrecognized optionality: "${match.groups.required}"`);
         }
+        let type = match.groups.type;
+        if (type && !types.isExpectedType(type)){
+            logger.warn(`For header "${rawHeader.name}" found unknown type: ${type}; type checking will be disabled for this header.`);
+            type = '';
+        }
+
         return {
             name: rawHeader.name,
             value: match.groups.value,
-            type: match.groups.type,
+            type: type,
             required: required,
         };
     }

--- a/src/lib/parse/resources.js
+++ b/src/lib/parse/resources.js
@@ -67,6 +67,11 @@ const separatePathAndQueryParams = function (parsedUrl: ParsedUrl, resource: Blu
     let queryParams = {};
     let pathParams = {};
     resource.parameters && resource.parameters.forEach(param => {
+        if (param.type && !types.isExpectedType(param.type)) {
+            logger.warn(`For parameter "${param.name}" found unknown type: ${param.type}; type checking will be disabled for this parameter.`);
+            param.type = '';
+        }
+
         if (queryParamKeys.includes(param.name)) {
             queryParams[param.name] = param;
         } else if (pathParamKeys.includes(param.name)) {

--- a/src/lib/parse/types-checker.js
+++ b/src/lib/parse/types-checker.js
@@ -1,5 +1,5 @@
 //@flow
-
+const logger = require('../logging/logger');
 const isArray = (subject: any): boolean => {
     if (Array.isArray(subject)) {
         return true;
@@ -77,7 +77,23 @@ exports.typeMatches = (subject: any, type: string): boolean => {
         case "string":
             return isString(subject);
         default:
-            throw new Error(`trying to test for unknown type ${type}`)
+            logger.warn(`Trying to do type check for unknown type ${type}. Allowing match.`)
+            return true;
     }
 };
 
+const expectedTypes = [
+    "string",
+    "number",
+    "boolean",
+    "object",
+    "array",
+];
+
+exports.isExpectedType = (type: string): boolean => {
+    // allow 'array[<type>]
+    if (type.startsWith("array")) {
+        return true;
+    }
+    return expectedTypes.includes(type);
+};

--- a/src/test/unit/parse/headers-test.js
+++ b/src/test/unit/parse/headers-test.js
@@ -28,14 +28,14 @@ describe('parseHeaderValue', () => {
     describe('GIVEN a value that has a type and optionality is left out', () => {
         const rawHeader: HeaderDef = {
             name: 'name',
-            value: 'value (type)',
+            value: 'value (string)',
             type: '',
         };
 
         const expected: HeaderDef = {
             name: 'name',
             value: 'value',
-            type: 'type',
+            type: 'string',
             required: true
         };
 
@@ -47,14 +47,14 @@ describe('parseHeaderValue', () => {
     describe('GIVEN a value that has a type and optionality is `optional`', () => {
         const rawHeader: HeaderDef = {
             name: 'name',
-            value: 'value (type, optional)',
+            value: 'value (string, optional)',
             type: '',
         };
 
         const expected: HeaderDef = {
             name: 'name',
             value: 'value',
-            type: 'type',
+            type: 'string',
             required: false
         };
 
@@ -66,7 +66,7 @@ describe('parseHeaderValue', () => {
     describe('GIVEN a value that has a type and optionality is not `optional` or `required`', () => {
         const rawHeader: HeaderDef = {
             name: 'name',
-            value: 'value (type, some other value)',
+            value: 'value (string, some other value)',
             type: '',
         };
 
@@ -78,13 +78,13 @@ describe('parseHeaderValue', () => {
     describe('GIVEN value in back ticks', () => {
         const rawHeader: HeaderDef = {
             name: 'name',
-            value: '`some value` (type)',
+            value: '`some value` (string)',
             type: '',
         };
         const expected: HeaderDef = {
             name: 'name',
             value: 'some value',
-            type: 'type',
+            type: 'string',
             required: true
         };
 
@@ -96,17 +96,35 @@ describe('parseHeaderValue', () => {
     describe('GIVEN value with trailing whitespace', () => {
         const rawHeader: HeaderDef = {
             name: 'name',
-            value: 'some value          (type)',
+            value: 'some value          (string)',
             type: '',
         };
         const expected: HeaderDef = {
             name: 'name',
             value: 'some value',
-            type: 'type',
+            type: 'string',
             required: true
         };
 
         it('THEN it returns trimmed value', () => {
+            assert.deepEqual(headers.parseHeaderValue(rawHeader), expected);
+        });
+    });
+
+    describe('GIVEN unexpected type', () => {
+        const rawHeader: HeaderDef = {
+            name: 'name',
+            value: 'some value (not a type)',
+            type: '',
+        };
+        const expected: HeaderDef = {
+            name: 'name',
+            value: 'some value',
+            type: '',
+            required: true
+        };
+
+        it('THEN it returns empty type', () => {
             assert.deepEqual(headers.parseHeaderValue(rawHeader), expected);
         });
     });

--- a/src/test/unit/parse/resources-test.js
+++ b/src/test/unit/parse/resources-test.js
@@ -57,6 +57,39 @@ describe('separatePathAndQueryParams', () => {
 
             assert.deepStrictEqual(resources.separatePathAndQueryParams(parsedUrl, resource), expected);
         });
+    });
+
+    describe('Given a parameter with an unexpected type', () => {
+        const pathA: Parameter = {
+            name: 'A',
+            type: 'unknown',
+            required: true,
+        };
+
+        const resource: BlueprintResource = {
+            actions: [],
+            parameters: [pathA],
+            uriTemplate: '',
+        };
+        const expectedParam: Parameter = {
+            name: 'A',
+            type: '',
+            required: true,
+        };
+
+        const parsedUrl: ParsedUrl = {
+            url: '/:A/:C',
+            queryParams: {},
+        };
+
+        it('WHEN calling separatePathAndQueryParams, it returns the param with type removed', () => {
+            const expected = {
+                pathParams: {'A': expectedParam},
+                queryParams: {},
+            };
+
+            assert.deepStrictEqual(resources.separatePathAndQueryParams(parsedUrl, resource), expected);
+        });
 
     });
 });
@@ -85,7 +118,7 @@ describe('removeInvalidFixtures', () => {
     describe('WHEN the fixture is valid', () => {
         const fixtureUrl: ParsedUrl = {
             uriTemplate: '/demo/{pathparam}',
-            queryParams: {'q':''},
+            queryParams: {'q': ''},
             url: '/demo/:pathparam'
         };
 
@@ -110,7 +143,7 @@ describe('removeInvalidFixtures', () => {
     describe('WHEN the fixture is valid', () => {
         const fixtureUrl: ParsedUrl = {
             uriTemplate: '/demo/{pathparam}',
-            queryParams: {'q':''},
+            queryParams: {'q': ''},
             url: '/demo/:pathparam'
         };
 
@@ -160,7 +193,7 @@ describe('removeInvalidFixtures', () => {
     describe('WHEN the fixture has query parameter of wrong type', () => {
         const fixtureUrl: ParsedUrl = {
             uriTemplate: '/demo/{pathparam}',
-            queryParams: {'q':''},
+            queryParams: {'q': ''},
             url: '/demo/:pathparam'
         };
 
@@ -185,7 +218,7 @@ describe('removeInvalidFixtures', () => {
     describe('WHEN the fixture has query value that is wrong type', () => {
         const fixtureUrl: ParsedUrl = {
             uriTemplate: '/demo/{pathparam}',
-            queryParams: {'q':'asd'},
+            queryParams: {'q': 'asd'},
             url: '/demo/:pathparam'
         };
 
@@ -210,7 +243,7 @@ describe('removeInvalidFixtures', () => {
     describe('WHEN the fixture has a query parameter not required that is in the contract', () => {
         const fixtureUrl: ParsedUrl = {
             uriTemplate: '/demo/{pathparam}',
-            queryParams: {'q':''},
+            queryParams: {'q': ''},
             url: '/demo/:pathparam'
         };
 
@@ -235,7 +268,7 @@ describe('removeInvalidFixtures', () => {
     describe('WHEN the fixture is missing path parameter details', () => {
         const fixtureUrl: ParsedUrl = {
             uriTemplate: '/demo/{pathparam}',
-            queryParams: {'q':''},
+            queryParams: {'q': ''},
             url: '/demo/:pathparam'
         };
 
@@ -255,7 +288,7 @@ describe('removeInvalidFixtures', () => {
     describe('WHEN the fixture has a path parameter not correct type', () => {
         const fixtureUrl: ParsedUrl = {
             uriTemplate: '/demo/abc',
-            queryParams: {'q':''},
+            queryParams: {'q': ''},
             url: '/demo/abc'
         };
 
@@ -280,7 +313,7 @@ describe('removeInvalidFixtures', () => {
     describe('WHEN the fixture has a path parameter as wrong type', () => {
         const fixtureUrl: ParsedUrl = {
             uriTemplate: '/demo/{pathparam}',
-            queryParams: {'q':''},
+            queryParams: {'q': ''},
             url: '/demo/:pathparam'
         };
 

--- a/src/test/unit/types-checker-test.js
+++ b/src/test/unit/types-checker-test.js
@@ -109,8 +109,8 @@ describe('type checker', () => {
     });
 
     describe('GIVEN the type is unexpected', () => {
-        it('THEN it throws error', () => {
-            assert.throws(() => types.typeMatches(null, 'shmergenbergen'));
+        it('THEN it returns true', () => {
+            assert.ok(types.typeMatches(null, 'shmergenbergen'));
         });
     });
 


### PR DESCRIPTION
Avoid throwing errors when making a request to an endpoint where contract has an unexpected type for a parameter or header