### PR TITLE
PLAT-5479 validate json headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,20 @@ The format is based on the MSON format that apib uses:
 ```
     <header name>: `<example value>` (<type>, required | optional) - <description>
 ```
-Headers that have only an example value will be an exact match as drakov has always worked; otherwise, they will match
-as long as they are the proper type.
+Validation order:
+1. when header has a type in the spec the value is ignored and only type is compared with the request.
+```
+    x-user-id: 12345 (string) - matches x-user-id=whatever
+```
+2. when header has only value in the spec, and the value is a parsable json object, the resulting json is used for matching.
+Json matching allows backward compatible changes like field reordering and addition.
+```
+    x-user: {"id":"123"} - matches x-user={"new_field":"new_val","id":"123"}
+```
+3. when header has only value and is not a parsable json object the value is used for matching
+```
+    x-country-code: USA - matches x-country-code=USA
+```
 
 The headers still need to be in a pre-formatted block, with one header per line
 and must **not** have a list item marker (+ or -) in front, unlike parameters. This is to allow

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -4,6 +4,7 @@ var specSchema = require('./spec-schema');
 var contentTypeChecker = require('./content-type');
 var strictSchemas = require('./strict-schemas');
 var types = require('./parse/types-checker');
+var headers = require('./parse/headers');
 
 var isJson = contentTypeChecker.isJson;
 
@@ -158,20 +159,30 @@ exports.matchesHeader = function (httpReq, specReq, ignoreHeaders) {
         const reqValue = httpReq.headers[headerName];
         if (specHeader.type) {
             if (!types.headerTypeMatches(reqValue, specHeader.type)) {
-                logger.debug(`Matching by request header: For "${headerName}" expected type "${specHeader.type}" but got value "${reqValue}" ${'NOT_MATCHED'.red}`);
+                logger.debug(`Matching by request header type: For "${headerName}" expected type "${specHeader.type}" but got value "${reqValue}" ${'NOT_MATCHED'.red}`);
                 return false;
             } else {
-                logger.debug(`Matching by request header: "${headerName}" ${'MATCHED'.green}`);
+                logger.debug(`Matching by request header type: "${headerName}" matched type ${specHeader.type} ${'MATCHED'.green}`);
                 return true;
             }
         }
 
+        if (specHeader.jsonValue) {
+            if(lodash.isMatch(headers.parseJsonHeaderObject(reqValue), specHeader.jsonValue)) {
+                logger.debug(`Matching by request header json: "${headerName}" spec is a subset of request ${'MATCHED'.green}`);
+                return true;
+            } else {
+                logger.debug(`Matching by request header json: For "${headerName}" expected value "${specHeader.value}" but got value "${reqValue}" ${'NOT_MATCHED'.red}`);
+                return false;
+            }
+        }
+
         if (reqValue !== specHeader.value) {
-            logger.debug(`Matching by request header: For "${headerName}" expected value "${specHeader.value}" but got value "${reqValue}" ${'NOT_MATCHED'.red}`);
+            logger.debug(`Matching by request header string: For "${headerName}" expected value "${specHeader.value}" but got value "${reqValue}" ${'NOT_MATCHED'.red}`);
             return false;
         }
 
-        logger.debug(`Matching by request header: "${headerName}" ${'MATCHED'.green}`);
+        logger.debug(`Matching by request header string: "${headerName}" matched string ${specHeader.value} ${'MATCHED'.green}`);
         return true;
     }
 

--- a/src/test/api/contract-scenario-headers-test.js
+++ b/src/test/api/contract-scenario-headers-test.js
@@ -121,8 +121,6 @@ describe('Contract Scenarios Headers Validation', () => {
                     .end(done);
             });
         });
-
-
     });
 });
 
@@ -132,27 +130,31 @@ function fullMatchRequest() {
         .set('stringRequired', 'a string')
         .set('numberRequired', '234')
         .set('stringOptional', 'also a string')
-        .set('value', 'some value');
+        .set('value', 'some value')
+        .set('jsonValue', JSON.stringify({key3: 'val3', key1: 'val1'}));
 }
 
 function onlyRequiredRequest() {
     return request.get('/header-types/only-required-match')
         .set('stringRequired', 'a string')
         .set('numberRequired', '234')
-        .set('value', 'some value');
+        .set('value', 'some value')
+        .set('jsonValue', JSON.stringify({key3: 'val3', key1: 'val1'}));
 }
 
 function missingRequiredRequest() {
     return request.get('/header-types/missing-required')
         .set('numberRequired', '234')
-        .set('value', 'some value');
+        .set('value', 'some value')
+        .set('jsonValue', JSON.stringify({key3: 'val3', key1: 'val1'}));
 }
 
 function wrongTypeRequest() {
     return request.get('/header-types/wrong-type')
         .set('stringRequired', 'a string')
         .set('numberRequired', '234')
-        .set('value', 'some value');
+        .set('value', 'some value')
+        .set('jsonValue', JSON.stringify({key3: 'val3', key1: 'val1'}));
 }
 
 function missingValueRequest() {

--- a/src/test/api/contract-scenario-headers-test.js
+++ b/src/test/api/contract-scenario-headers-test.js
@@ -120,6 +120,12 @@ describe('Contract Scenarios Headers Validation', () => {
                     .expect(404)
                     .end(done);
             });
+
+            it('responds with 400 to a wrong json header', (done) => {
+                wrongJsonRequest()
+                    .expect(400)
+                    .end(done);
+            });
         });
     });
 });
@@ -161,4 +167,13 @@ function missingValueRequest() {
     return request.get('/header-types/missing-value')
         .set('stringRequired', 'a string')
         .set('numberRequired', '234');
+}
+
+function wrongJsonRequest() {
+    return request.get('/header-types/wrong-json')
+        .set('stringRequired', 'a string')
+        .set('numberRequired', '234')
+        .set('stringOptional', 'also a string')
+        .set('value', 'some value')
+        .set('jsonValue', JSON.stringify({key3: 'val3', key1: 'wrong'}));
 }

--- a/src/test/example/contract/scenario-headers-validation.apib
+++ b/src/test/example/contract/scenario-headers-validation.apib
@@ -26,5 +26,6 @@
               numberRequired: (number)
               stringOptional: (string, optional)
               value: some value
-    
+              jsonValue: {"key1":"val1"}
+
 + Response 200

--- a/src/test/example/scenarios/headers/scenario-headers.apib
+++ b/src/test/example/scenarios/headers/scenario-headers.apib
@@ -94,3 +94,17 @@
 
 + Response 200
 
+## Headers with types [/header-types/wrong-json]
+
+### GET
+
++ Request
+    + Headers
+
+            stringRequired: (string)
+            numberRequired: (number)
+            stringOptional: (string, optional)
+            value: some value
+            jsonValue: {"key1":"val1"}
+
++ Response 200

--- a/src/test/example/scenarios/headers/scenario-headers.apib
+++ b/src/test/example/scenarios/headers/scenario-headers.apib
@@ -38,6 +38,7 @@
             numberRequired: (number)
             stringOptional: (string, optional)
             value: some value
+            jsonValue: {"key1":"val1"}
 
 + Response 200
 
@@ -50,6 +51,7 @@
             stringRequired: (string)
             numberRequired: (number)
             value: some value
+            jsonValue: {"key1":"val1"}
 
 + Response 200
 
@@ -62,6 +64,7 @@
             numberRequired: (number)
             stringOptional: (string, optional)
             value: some value
+            jsonValue: {"key1":"val1"}
 
 + Response 200
 
@@ -75,6 +78,7 @@
             numberRequired: (string)
             stringOptional: (string, optional)
             value: some value
+            jsonValue: {"key1":"val1"}
 
 + Response 200
 

--- a/src/test/unit/content-test.js
+++ b/src/test/unit/content-test.js
@@ -310,7 +310,8 @@
                     'random-value': 'random',
                     'content-type': 'application/json',
                     'hello': 'World',
-                    'custom-header': 'test'
+                    'custom-header': 'test',
+                    'json-header': '{"key":"val"}',
                 }
             };
 
@@ -368,7 +369,8 @@
                     headers: [
                         {name: 'Content-Type', value: 'application/json'},
                         {name: 'Custom-header', value: 'test'},
-                        {name: 'Hello', value: 'World'}
+                        {name: 'Hello', value: 'World'},
+                        {name: 'json-header', jsonValue: {key: 'val'}}
                     ]
                 };
 
@@ -400,6 +402,7 @@
                         {name: 'Custom-header', value: 'test'},
                         {name: 'Hello', value: 'World'},
                         {name: 'some-another-header', value: 'some value', required: true},
+                        {name: 'json-header', jsonValue: {key: 'wrong'}},
                     ]
                 };
 

--- a/src/test/unit/parse/headers-test.js
+++ b/src/test/unit/parse/headers-test.js
@@ -128,6 +128,27 @@ describe('parseHeaderValue', () => {
             assert.deepEqual(headers.parseHeaderValue(rawHeader), expected);
         });
     });
+
+    describe('GIVEN a valid json object value', () => {
+        const rawHeader: HeaderDef = {
+            name: 'name',
+            value: '{"key1":"val1"} (string)',
+            type: '',
+        };
+        const expected: HeaderDef = {
+            name: 'name',
+            value: '{"key1":"val1"}',
+            type: 'string',
+            required: true,
+            jsonValue : {
+                key1: 'val1',
+            },
+        };
+
+        it('THEN it returns jsonValue property', () => {
+            assert.deepEqual(headers.parseHeaderValue(rawHeader), expected);
+        });
+    });
 });
 
 describe('compareFixtureAndContractHeaders', () => {
@@ -264,5 +285,28 @@ describe('compareFixtureAndContractHeaders', () => {
         });
 
     });
+});
 
+describe('parseJsonHeaderObject', () => {
+    describe('When string is a valid json object', () => {
+        const str = '{"key":"val"}'
+
+        it('then it returns parsed object', () => {
+            assert.deepStrictEqual(headers.parseJsonHeaderObject(str), JSON.parse(str));
+        });
+    });
+    describe('When string is not a valid json object', () => {
+        const str = '1'
+
+        it('then it returns empty', () => {
+            assert.deepStrictEqual(headers.parseJsonHeaderObject(str), '');
+        });
+    });
+    describe('When string is a malformed json', () => {
+        const str = '{"key":"val"'
+
+        it('then it returns empty', () => {
+            assert.deepStrictEqual(headers.parseJsonHeaderObject(str), '');
+        });
+    });
 });


### PR DESCRIPTION
The idea is to match JSON headers as objects and allow backward-compatible changes. So adding a property or reordering properties should not break the contract.
Example: request with x-my-header:{"new_key":"new_val","key1":"val1"} should match spec with x-my-header:{"key1":"val1"}